### PR TITLE
[ci skip] Fix errorneous conda-forge.yml

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,7 @@
 bot:
   inspection: update-grayskull
-conda_forge_output_validation: true
-bot:
   automerge: false
+conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
This causes the @regro-cf-autotick-bot to hiccup on this feedstock.